### PR TITLE
Add support for Meteor 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - stable
+  - 10
 before_install:
   - curl -L https://raw.githubusercontent.com/arunoda/travis-ci-meteor-packages/master/configure.sh | /bin/sh
   - npm install -g codeclimate-test-reporter

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,6 +3,77 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@mihon/spacejam": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@mihon/spacejam/-/spacejam-1.6.4.tgz",
+      "integrity": "sha512-Daz+TVbm7f5W+OFk6kPuGHR97CbsHJM1Wvi/ZrRG0BtTmqhKhBg8QePCKXDVMEv5A3m4stJPOBG8BtQpUO5sjQ==",
+      "dev": true,
+      "requires": {
+        "cake": "^0.1.1",
+        "chai": "1.9.2",
+        "glob": "4.0.6",
+        "graceful-fs": "^4.2.4",
+        "loglevel": "1.1.0",
+        "phantomjs-prebuilt": "^2.1.7",
+        "psext": "0.0.4",
+        "rc": "0.5.1",
+        "semver": "4.1.0",
+        "underscore": "1.7.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
+          "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^3.0.2",
+            "inherits": "2",
+            "minimatch": "^1.0.0",
+            "once": "^1.3.0"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.12",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.12.tgz",
+              "integrity": "sha512-J55gaCS4iTTJfTXIxSVw3EMQckcqkpdRv3IR7gu6sq0+tbC363Zx6KH/SEwXASK9JRbhyZmVjJEVJIOxYsB3Qg==",
+              "dev": true,
+              "requires": {
+                "natives": "^1.1.3"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+          "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
+          }
+        },
+        "semver": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.1.0.tgz",
+          "integrity": "sha1-vICp/2hTKBQ2LMPP2jx7de2cMhw=",
+          "dev": true
+        }
+      }
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -166,6 +237,23 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "cake": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/cake/-/cake-0.1.1.tgz",
+      "integrity": "sha1-SmXQ2vsBgYAjFipxc0DdiOB4Wzc=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "^1.12.7"
+      },
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.12.7",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+          "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+          "dev": true
+        }
+      }
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
@@ -243,23 +331,6 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
-    "coffee-script": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.8.0.tgz",
-      "integrity": "sha1-nJ8dK0pSoADe0Vtll5FwNkgmPB0=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "~0.3.5"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        }
-      }
-    },
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
@@ -298,16 +369,6 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
-    },
-    "cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
     },
     "d": {
       "version": "1.0.0",
@@ -841,15 +902,6 @@
         "mime-types": "^2.1.12"
       }
     },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "~1.1"
-      }
-    },
     "fs-extra": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
@@ -1338,22 +1390,6 @@
       "integrity": "sha1-gslPm3N3S0oc0uSuZWKzqLZ230s=",
       "dev": true
     },
-    "lolex": {
-      "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
@@ -1658,12 +1694,6 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "psext": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/psext/-/psext-0.0.4.tgz",
@@ -1886,12 +1916,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
-    },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
@@ -1915,87 +1939,11 @@
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
     },
-    "sinon": {
-      "version": "1.17.7",
-      "resolved": "http://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
-      "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
-      }
-    },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "spacejam": {
-      "version": "https://github.com/serut/spacejam/tarball/windows-suppport-rc4",
-      "integrity": "sha512-uR333uU7kmJu8uNXNPPpEn+LU5Qs+zgOhimxmpi3MZDYo+5n6nlE757OuZ+dgk4zf+teXy5Lt2HdtBVSxTem1Q==",
-      "dev": true,
-      "requires": {
-        "chai": "1.9.2",
-        "coffee-script": "1.8.0",
-        "cross-spawn": "^4.0.0",
-        "glob": "4.0.6",
-        "loglevel": "1.1.0",
-        "phantomjs-prebuilt": "^2.1.7",
-        "psext": "0.0.4",
-        "rc": "0.5.1",
-        "semver": "4.1.0",
-        "sinon": "^1.17.4",
-        "try-thread-sleep": "1.0.0",
-        "underscore": "1.7.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.0.6.tgz",
-          "integrity": "sha1-aVxQvdTi+1xdNwsJHziNNwfikac=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^3.0.2",
-            "inherits": "2",
-            "minimatch": "^1.0.0",
-            "once": "^1.3.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "3.0.11",
-          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-          "dev": true,
-          "requires": {
-            "natives": "^1.1.0"
-          }
-        },
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "semver": {
-          "version": "4.1.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-4.1.0.tgz",
-          "integrity": "sha1-vICp/2hTKBQ2LMPP2jx7de2cMhw=",
-          "dev": true
-        }
-      }
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -2158,13 +2106,6 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
-    "thread-sleep": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/thread-sleep/-/thread-sleep-2.1.0.tgz",
-      "integrity": "sha512-VC9Uhr3k2tP/daEKACIamL00ETclXwku39HDHvvgk+pEhi592iLDT7YQUMYLRWCkZcVU1OcsbaoEP7pE/go6YA==",
-      "dev": true,
-      "optional": true
-    },
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
@@ -2193,15 +2134,6 @@
           "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true
         }
-      }
-    },
-    "try-thread-sleep": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/try-thread-sleep/-/try-thread-sleep-1.0.0.tgz",
-      "integrity": "sha1-aPoeH+4C/cLwwaLLPHv8mB98CcA=",
-      "dev": true,
-      "requires": {
-        "thread-sleep": "*"
       }
     },
     "tunnel-agent": {
@@ -2262,15 +2194,6 @@
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
-      }
-    },
-    "util": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
@@ -2340,12 +2263,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },
     "yauzl": {

--- a/package.js
+++ b/package.js
@@ -2,14 +2,18 @@
 
 Package.describe({
   name: 'lucasantoniassi:accounts-lockout',
-  version: '1.0.0',
+  version: '1.0.1',
   summary: 'Meteor package for locking user accounts and stopping brute force attacks',
   git: 'https://github.com/lucasantoniassi/meteor-accounts-lockout.git',
   documentation: 'README.md',
 });
 
 Package.onUse((api) => {
-  api.versionsFrom('1.4.2.3');
+  api.versionsFrom([
+    '1.4.2.3',
+    '2.3',
+  ]);
+
   api.use([
     'ecmascript',
     'accounts-password',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:coverage": "npm run lint && spacejam test-packages ./ --coverage --driver-package cultofcoders:mocha"
   },
   "devDependencies": {
-    "spacejam": "https://github.com/serut/spacejam/tarball/windows-suppport-rc4",
+    "@mihon/spacejam": "^1.6.4",
     "eslint": "^3.12.2",
     "eslint-config-airbnb": "^13.0.0",
     "eslint-plugin-import": "^2.1.0",


### PR DESCRIPTION
Makes this package compatible with Meteor 2.3.x.

**NOTE:**

I wasn't able to run tests locally since the following dependency can't be resolved:

`"spacejam": "https://github.com/serut/spacejam/tarball/windows-suppport-rc4"`

Tried using [version from NPM](https://www.npmjs.com/package/spacejam)  but it's failing with the following error:

```
Fontconfig error: "/etc/fonts/local.conf", line 1: XML declaration not well-formed
phantomjs: Running tests at http://localhost:4096/local using test-in-console
phantomjs: TypeError: undefined is not an object (evaluating 'Package.modules.meteorInstall')
```

let's see what CI says.